### PR TITLE
Fully parse DNS rcode status

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -1011,3 +1011,69 @@ void DNSCreateTypeString(uint16_t type, char *str, size_t str_size)
             snprintf(str, str_size, "%04x/%u", type, type);
     }
 }
+
+void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size)
+{
+    switch (rcode) {
+        case DNS_RCODE_NOERROR:
+            snprintf(str, str_size, "NOERROR");
+            break;
+        case DNS_RCODE_FORMERR:
+            snprintf(str, str_size, "FORMERR");
+            break;
+        case DNS_RCODE_SERVFAIL:
+            snprintf(str, str_size, "SERVFAIL");
+            break;
+        case DNS_RCODE_NXDOMAIN:
+            snprintf(str, str_size, "NXDOMAIN");
+            break;
+        case DNS_RCODE_NOTIMP:
+            snprintf(str, str_size, "NOTIMP");
+            break;
+        case DNS_RCODE_REFUSED:
+            snprintf(str, str_size, "REFUSED");
+            break;
+        case DNS_RCODE_YXDOMAIN:
+            snprintf(str, str_size, "YXDOMAIN");
+            break;
+        case DNS_RCODE_YXRRSET:
+            snprintf(str, str_size, "YXRRSET");
+            break;
+        case DNS_RCODE_NXRRSET:
+            snprintf(str, str_size, "NXRRSET");
+            break;
+        case DNS_RCODE_NOTAUTH:
+            snprintf(str, str_size, "NOTAUTH");
+            break;
+        case DNS_RCODE_NOTZONE:
+            snprintf(str, str_size, "NOTZONE");
+            break;
+        /* these are the same, need more logic */
+        case DNS_RCODE_BADVERS:
+        //case DNS_RCODE_BADSIG:
+            snprintf(str, str_size, "BADVERS/BADSIG");
+            break;
+        case DNS_RCODE_BADKEY:
+            snprintf(str, str_size, "BADKEY");
+            break;
+        case DNS_RCODE_BADTIME:
+            snprintf(str, str_size, "BADTIME");
+            break;
+        case DNS_RCODE_BADMODE:
+            snprintf(str, str_size, "BADMODE");
+            break;
+        case DNS_RCODE_BADNAME:
+            snprintf(str, str_size, "BADNAME");
+            break;
+        case DNS_RCODE_BADALG:
+            snprintf(str, str_size, "BADALG");
+            break;
+        case DNS_RCODE_BADTRUNC:
+            snprintf(str, str_size, "BADTRUNC");
+            break;
+        default:
+            SCLogDebug("could not map DNS rcode to name, bug!");
+            snprintf(str, str_size, "%04x/%u", rcode, rcode);
+    }
+}
+

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -60,6 +60,26 @@
 
 #define DNS_RECORD_TYPE_ANY     255
 
+#define DNS_RCODE_NOERROR       0
+#define DNS_RCODE_FORMERR       1
+#define DNS_RCODE_SERVFAIL      2
+#define DNS_RCODE_NXDOMAIN      3
+#define DNS_RCODE_NOTIMP        4
+#define DNS_RCODE_REFUSED       5
+#define DNS_RCODE_YXDOMAIN      6
+#define DNS_RCODE_YXRRSET       7
+#define DNS_RCODE_NXRRSET       8
+#define DNS_RCODE_NOTAUTH       9
+#define DNS_RCODE_NOTZONE       10
+#define DNS_RCODE_BADVERS       16
+#define DNS_RCODE_BADSIG        16
+#define DNS_RCODE_BADKEY        17
+#define DNS_RCODE_BADTIME       18
+#define DNS_RCODE_BADMODE       19
+#define DNS_RCODE_BADNAME       20
+#define DNS_RCODE_BADALG        21
+#define DNS_RCODE_BADTRUNC      22
+
 enum {
     DNS_DECODER_EVENT_UNSOLLICITED_RESPONSE,
     DNS_DECODER_EVENT_MALFORMED_DATA,
@@ -139,7 +159,7 @@ typedef struct DNSTransaction_ {
     uint8_t replied;                                /**< bool indicating request is
                                                          replied to. */
     uint8_t reply_lost;
-    uint8_t no_such_name;                           /**< server said "no such name" */
+    uint8_t rcode;                                  /**< response code (e.g. "no error" / "no such name") */
     uint8_t recursion_desired;                      /**< server said "recursion desired" */
 
     TAILQ_HEAD(, DNSQueryEntry_) query_list;        /**< list for query/queries */
@@ -223,5 +243,6 @@ uint16_t DNSUdpResponseGetNameByOffset(const uint8_t * const input, const uint32
         const uint16_t offset, uint8_t *fqdn, const size_t fqdn_size);
 
 void DNSCreateTypeString(uint16_t type, char *str, size_t str_size);
+void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size);
 
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -269,11 +269,15 @@ static int DNSUDPResponseParse(Flow *f, void *dstate,
         }
     }
 
-    /* see if this is a "no such name" error */
-    if (ntohs(dns_header->flags) & 0x0003) {
-        SCLogDebug("no such name");
+    /* parse rcode, e.g. "noerror" or "nxdomain" */
+    uint8_t rcode = ntohs(dns_header->flags) & 0x0F;
+    if (rcode <= 10 || (rcode >= 16 && rcode <= 22)) {
+        SCLogDebug("rcode %u", rcode);
         if (tx != NULL)
-            tx->no_such_name = 1;
+            tx->rcode = rcode;
+    } else {
+        /* this is not invalid, rcodes can be user defined */
+        SCLogDebug("unexpected DNS rcode %u", rcode);
     }
 
     if (ntohs(dns_header->flags) & 0x0080) {

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -40,6 +40,7 @@
 
 #include "output.h"
 #include "log-dnslog.h"
+#include "app-layer-dns-common.h"
 #include "app-layer-dns-udp.h"
 #include "app-layer.h"
 #include "util-privs.h"
@@ -109,16 +110,19 @@ static void LogAnswer(LogDnsLogThread *aft, char *timebuf, char *srcip, char *ds
 
     /* reset */
     MemBufferReset(aft->buffer);
-
+    /* time & tx*/
     /* time & tx*/
     MemBufferWriteString(aft->buffer,
             "%s [**] Response TX %04x [**] ", timebuf, tx->tx_id);
 
     if (entry == NULL) {
-        if (tx->no_such_name)
-            MemBufferWriteString(aft->buffer, "No Such Name");
-        else if (tx->recursion_desired)
+        if (tx->rcode) {
+            char rcode[16] = "";
+            DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
+            MemBufferWriteString(aft->buffer, "%s", rcode);
+        } else if (tx->recursion_desired) {
             MemBufferWriteString(aft->buffer, "Recursion Desired");
+        }
     } else {
         /* query */
         if (entry->fqdn_len > 0) {
@@ -216,7 +220,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p, Flow *f,
         LogQuery(aft, timebuf, dstip, srcip, dp, sp, dns_tx, query);
     }
 
-    if (dns_tx->no_such_name)
+    if (dns_tx->rcode)
         LogAnswer(aft, timebuf, srcip, dstip, sp, dp, dns_tx, NULL);
     if (dns_tx->recursion_desired)
         LogAnswer(aft, timebuf, srcip, dstip, sp, dp, dns_tx, NULL);

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -126,6 +126,12 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, 
     /* id */
     json_object_set_new(js, "id", json_integer(tx->tx_id));
 
+    /* rcode */
+    char rcode[16] = "";
+    DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
+    json_object_set_new(js, "rcode", json_string(rcode));
+
+    /* we are logging an answer RR */
     if (entry != NULL) {
         /* query */
         if (entry->fqdn_len > 0) {
@@ -180,13 +186,55 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, 
     return;
 }
 
+static void OutputFailure(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, DNSQueryEntry *entry)
+{
+    MemBuffer *buffer = (MemBuffer *)aft->buffer;
+    json_t *js = json_object();
+    if (js == NULL)
+        return;
+
+    /* type */
+    json_object_set_new(js, "type", json_string("answer"));
+
+    /* id */
+    json_object_set_new(js, "id", json_integer(tx->tx_id));
+
+    /* rcode */
+    char rcode[16] = "";
+    DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
+    json_object_set_new(js, "rcode", json_string(rcode));
+
+    /* no answer RRs, use query for rname */
+    char *c;
+    c = BytesToString((uint8_t *)((uint8_t *)entry + sizeof(DNSQueryEntry)), entry->len);
+    if (c != NULL) {
+        json_object_set_new(js, "rrname", json_string(c));
+        SCFree(c);
+    }
+
+    /* reset */
+    MemBufferReset(buffer);
+    json_object_set_new(djs, "dns", js);
+    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, buffer);
+    json_object_del(djs, "dns");
+
+    return;
+}
+
 static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uint64_t tx_id)
 {
 
     SCLogDebug("got a DNS response and now logging !!");
 
-    if (tx->no_such_name) {
-        OutputAnswer(aft, js, tx, NULL);
+    /* rcode != noerror */
+    if (tx->rcode) {
+	/* Most DNS servers do not support multiple queries because
+	 * the rcode in response is not per-query.  Multiple queries
+	 * are likely to lead to FORMERR, so log this. */
+        DNSQueryEntry *query = NULL;
+        TAILQ_FOREACH(query, &tx->query_list, next) {
+            OutputFailure(aft, js, tx, query);
+	}
     }
 
     DNSAnswerEntry *entry = NULL;


### PR DESCRIPTION
Parse more than just NXDOMAIN flag.  Output this in JSON and DNS logs.

Note: Changes the output format in the DNS log from "No such domain" to "NXDOMAIN".